### PR TITLE
Add effect module

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ npm install raj
 - `raj/message`: define message and message unions
   - `message([displayName])`: create a message
   - `message.union([displayName, ] messages)`: create a message union
+- `raj/effect`: group and transform effects
+  - `effect.map(mapper, effect)`: transforms the dispatched values of `effect` using the function `mapper`
+  - `effect.batch(effects)`: group an array of effects into a single effect
 - `raj/react`: React bindings
   - `program(React, {init, update, view, flags})`: create a React component using the provided options
     - `React`: a version of React which has `React.Component`

--- a/effect.js
+++ b/effect.js
@@ -1,0 +1,28 @@
+function map (fn, effect) {
+  if (!effect) {
+    return effect
+  }
+
+  return function _map (dispatch, io) {
+    function intercept (message) {
+      dispatch(fn(message))
+    }
+
+    return effect(intercept, io)
+  }
+}
+
+function batch (effects) {
+  return function _batch (dispatch, ios = []) {
+    return effects.map((effect, index) => {
+      if (effect) {
+        return effect(dispatch, ios[index])
+      }
+    })
+  }
+}
+
+module.exports = {
+  map,
+  batch
+}

--- a/effect.js
+++ b/effect.js
@@ -3,20 +3,20 @@ function map (fn, effect) {
     return effect
   }
 
-  return function _map (dispatch, io) {
+  return function _map (dispatch) {
     function intercept (message) {
       dispatch(fn(message))
     }
 
-    return effect(intercept, io)
+    return effect(intercept)
   }
 }
 
 function batch (effects) {
-  return function _batch (dispatch, ios = []) {
-    return effects.map((effect, index) => {
+  return function _batch (dispatch) {
+    return effects.map(effect => {
       if (effect) {
-        return effect(dispatch, ios[index])
+        return effect(dispatch)
       }
     })
   }

--- a/test/effect.js
+++ b/test/effect.js
@@ -32,17 +32,6 @@ test('map() should not wrap a falsey effect', t => {
   })
 })
 
-test('map() should pass the second argument to the effect', t => {
-  const val = 1
-  const id = x => x
-  function rawEffect (dispatch, arg) {
-    t.is(arg, val)
-  }
-
-  const newEffect = effect.map(id, rawEffect)
-  newEffect(null, val)
-})
-
 test('map() should return the result of the effect', t => {
   const id = x => x
   const rawEffect = () => 1
@@ -77,16 +66,6 @@ test('batch() should not call falsey values', t => {
     const effects = effect.batch([null, false, undefined, 0])
     effects()
   })
-})
-
-test('batch() should pass each effect its second argument', t => {
-  const makeEffect = expectedArg => (dispatch, actualArg) => {
-    t.is(actualArg, expectedArg)
-  }
-
-  const args = [1, 2, 3]
-  const effects = effect.batch(args.map(makeEffect))
-  effects(null, args)
 })
 
 test('batch() should return the effects return values', t => {

--- a/test/effect.js
+++ b/test/effect.js
@@ -1,0 +1,97 @@
+import test from 'ava'
+import effect from '../effect'
+
+test('map() transforms any dispatched messages', t => {
+  function rawEffect (dispatch) {
+    dispatch(1)
+    dispatch(2)
+    dispatch(3)
+  }
+
+  const inc = n => n + 1
+  const newEffect = effect.map(inc, rawEffect)
+
+  const results = []
+  newEffect(result => results.push(result))
+
+  t.deepEqual(results, [2, 3, 4], 'results should have been incremented')
+})
+
+test('map() should not wrap a falsey effect', t => {
+  /*
+    The reasoning for this test is that commands can
+    be falsey and not run by the runtime.
+
+    map() should align with this behavior.
+  */
+
+  t.notThrows(() => {
+    const inc = n => n + 1
+    const newEffect = effect.map(inc, null)
+    t.is(newEffect, null)
+  })
+})
+
+test('map() should pass the second argument to the effect', t => {
+  const val = 1
+  const id = x => x
+  function rawEffect (dispatch, arg) {
+    t.is(arg, val)
+  }
+
+  const newEffect = effect.map(id, rawEffect)
+  newEffect(null, val)
+})
+
+test('map() should return the result of the effect', t => {
+  const id = x => x
+  const rawEffect = () => 1
+  const newEffect = effect.map(id, rawEffect)
+  t.is(newEffect(), 1, 'newEffect should return the effect value')
+})
+
+test('batch() should return a single effect', t => {
+  t.is(typeof effect.batch([]), 'function')
+})
+
+test('batch() should pass dispatch to each effect', t => {
+  const makeEffect = dispatchVal => dispatch => dispatch(dispatchVal)
+  const vals = [1, 2, 3]
+  const effects = effect.batch(vals.map(makeEffect))
+
+  const results = []
+  effects(result => results.push(result))
+
+  t.deepEqual(results, vals)
+})
+
+test('batch() should not call falsey values', t => {
+  /*
+    The reasoning for this test is that commands can
+    be falsey and not run by the runtime.
+
+    batch() should align with this behavior.
+  */
+
+  t.notThrows(() => {
+    const effects = effect.batch([null, false, undefined, 0])
+    effects()
+  })
+})
+
+test('batch() should pass each effect its second argument', t => {
+  const makeEffect = expectedArg => (dispatch, actualArg) => {
+    t.is(actualArg, expectedArg)
+  }
+
+  const args = [1, 2, 3]
+  const effects = effect.batch(args.map(makeEffect))
+  effects(null, args)
+})
+
+test('batch() should return the effects return values', t => {
+  const makeEffect = returnVal => dispatch => returnVal
+  const vals = [1, 2, 3]
+  const effects = effect.batch(vals.map(makeEffect))
+  t.deepEqual(effects(), vals)
+})


### PR DESCRIPTION
This PR adds helpers for effects. I am hesitant to add anything but the essentials to this framework's API surface. These effect helpers I believe are foundational to building decomposed apps and assembling them together. To ask users to write these helpers by hand has problems:

- Errors, as they may not be tested with the scrutiny I test with
- Inconsistency, as there are many ways to implement the happy path without the edge cases
- Familiarity is lost, as everyone lacks a shared foundation moving between re-created helpers

For these reasons, I believe this module is worth adding.