### PR TITLE
Accept a Component, not React

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ npm install raj
 
 #### Integrations
 - `raj/react`: React bindings
-  - `program(React, {init, update, view})`: create a React program
-    - `React`: a version of React which has `React.Component`
+  - `program(Component, {init, update, view})`: create a React program
+    - `Component`: a React or Preact Component class
     - `init(props)`: return the initial state and optional effect
     - `update(message, state)`: return the new state and optional effect
     - `view(state, dispatch)`: return the React view

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install raj
 #### Integrations
 - `raj/react`: React bindings
   - `program(Component, {init, update, view})`: create a React program
-    - `Component`: a React or Preact Component class
+    - `Component`: a React Component class
     - `init(props)`: return the initial state and optional effect
     - `update(message, state)`: return the new state and optional effect
     - `view(state, dispatch)`: return the React view

--- a/examples/make-n-model.js
+++ b/examples/make-n-model.js
@@ -59,7 +59,7 @@ export function view (state, dispatch) {
 }
 
 export default function main () {
-  return react.program(React, {
+  return react.program(React.Component, {
     init,
     update,
     view

--- a/examples/search.js
+++ b/examples/search.js
@@ -80,7 +80,7 @@ export function fetchResults (query) {
 }
 
 export function main () {
-  return react.program(React, {
+  return react.program(React.Component, {
     init,
     update,
     view

--- a/react.js
+++ b/react.js
@@ -1,7 +1,7 @@
 const {program} = require('./runtime')
 
-function reactProgram (React, {init, update, view}) {
-  return class ReactProgram extends React.Component {
+function reactProgram (Component, {init, update, view}) {
+  return class ReactProgram extends Component {
     constructor (props) {
       super(props)
       let initial = true

--- a/test/react.js
+++ b/test/react.js
@@ -4,7 +4,7 @@ import {program} from '../react'
 import {shallow} from 'enzyme'
 
 test('program() should return a React component', t => {
-  const Program = program(React, {
+  const Program = program(React.Component, {
     init: () => ['hello'],
     update: (msg, state) => [state],
     view: state => React.createElement('p', null, state)
@@ -17,7 +17,7 @@ test('program() should return a React component', t => {
 
 test('program() should update the React component', t => {
   let d
-  const Program = program(React, {
+  const Program = program(React.Component, {
     init: () => ['hello'],
     update: (msg, state) => [msg],
     view: (state, dispatch) => {
@@ -42,7 +42,7 @@ test('program() should update the React component', t => {
 
 test('program() should init with component props', t => {
   const props = {foo: 'bar'}
-  const Program = program(React, {
+  const Program = program(React.Component, {
     init: p => {
       t.deepEqual(p, props)
       return ['hello']


### PR DESCRIPTION
React offers `Component` and `PureComponent` classes to extend and since we don't need React itself for anything but the Component class asking for it directly allows people the choice.