### PR TITLE
Align runtime and React view functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ npm install raj
   - `effect.map(mapper, effect)`: transforms the dispatched values of `effect` using the function `mapper`
   - `effect.batch(effects)`: group an array of effects into a single effect
 - `raj/runtime`: create generic runtimes
-  - `program({init, update, renderer})`
+  - `program({init, update, view})`
     - `init`: the initial state and optional effect
     - `update(message, state)`: return the new state and optional effect
-    - `renderer(state, dispatch)`: use the state and dispatch messages
+    - `view(state, dispatch)`: use the state and dispatch messages
 
 #### Integrations
 - `raj/react`: React bindings

--- a/react.js
+++ b/react.js
@@ -8,7 +8,7 @@ function reactProgram (Component, {init, update, view}) {
       program({
         init: init(props),
         update,
-        renderer: (dispatch, state) => {
+        view: (state, dispatch) => {
           this._dispatch = dispatch
           if (initial) {
             this.state = {state}

--- a/runtime.js
+++ b/runtime.js
@@ -1,4 +1,4 @@
-function program ({init, update, renderer}) {
+function program ({init, update, view}) {
   let state
 
   function change ([newState, effect]) {
@@ -6,7 +6,7 @@ function program ({init, update, renderer}) {
     if (effect) {
       setTimeout(() => effect(dispatch), 0)
     }
-    renderer(dispatch, state)
+    view(state, dispatch)
   }
 
   function dispatch (message) {

--- a/test/runtime.js
+++ b/test/runtime.js
@@ -1,12 +1,12 @@
 import test from 'ava'
 import {program} from '../runtime'
 
-test('program() should call renderer() initially', t => {
+test('program() should call view() initially', t => {
   const initialState = 1
   return new Promise(resolve => {
     program({
       init: [initialState],
-      renderer (dispatch, state) {
+      view (state) {
         t.is(state, initialState)
         resolve()
       }
@@ -14,7 +14,7 @@ test('program() should call renderer() initially', t => {
   })
 })
 
-test('program() should call renderer() after dispatch', t => {
+test('program() should call view() after dispatch', t => {
   let count = 0
   return new Promise(resolve => {
     program({
@@ -22,7 +22,7 @@ test('program() should call renderer() after dispatch', t => {
       update (msg) {
         return [msg]
       },
-      renderer (dispatch, state) {
+      view (state, dispatch) {
         count++
         if (state === 'init') {
           return dispatch('next')


### PR DESCRIPTION
The `raj/runtime` `renderer` should be called `view`. I think both words are vague enough and "renderer" makes Raj sound too cool and complicated. I have also flipped the call order of the renderer which was `(dispatch, state)` and now `(state, dispatch)`. That was an ordering so poor, I even documented it wrong in the README originally.

This consistency is also important for me/library authors who now do not have to care about if people are using the raw runtime, React bindings, or something else. The `view` is the same everywhere.