### PR TITLE
Kill

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,28 @@ npm install raj
 [![Build Status](https://travis-ci.org/andrejewski/raj.svg?branch=master)](https://travis-ci.org/andrejewski/raj)
 [![Greenkeeper badge](https://badges.greenkeeper.io/andrejewski/raj.svg)](https://greenkeeper.io/)
 
+## Example
+A counter that increments by one every time the user confirms.
+
+```js
+import {program} from 'raj/runtime'
+
+program({
+  init: [0], // State is an integer to count
+  update (message, state) {
+    return [state + 1] // Increment the state
+  },
+  view (state, dispatch) {
+    const keepCounting = window.confirm(`Count is ${state}. Increment?`)
+    if (keepCounting) {
+      dispatch()
+    }
+  }
+})
+```
+
+*Note:* Raj is view layer agnostic. Here we use the browser's built-in view to play the part.
+
 ## Architecture
 
 The data flow is unidirectional.
@@ -46,35 +68,9 @@ interface RajProgram<State, Message, View> {
 }
 ```
 
-*Note: TypeScript is not required for Raj applications. This is hard to read, so I wanted syntax highlighting from a typed language.*
+*Note:* TypeScript is not required for Raj applications. This is hard to read, so I wanted syntax highlighting from a typed language.
 
-The `runtime` module itself is about 20 lines of JavaScript, which may be easier to understand for those who are not familiar with TypeScript.
-
-## Example
-A counter that increments by one every time the user confirms.
-
-```js
-import {program} from 'raj/runtime'
-
-// State: Integer - We need a single number to count
-// Message: void - We receive one message, increment
-// View: void - We use the confirm() pop-up as our "view"
-
-program({
-  init: [0],
-  update (message, state) {
-    return [state + 1]
-  },
-  view (state, dispatch) {
-    const keepCounting = window.confirm(`Count is ${state}. Increment?`)
-    if (keepCounting) {
-      dispatch()
-    }
-  }
-})
-```
-
-Examples exist in the `examples/` folder.
+The `runtime` module itself is about 40 lines of JavaScript, which may be easier to understand for those who are not familiar with TypeScript.
 
 ## Ecosystem
 

--- a/runtime.js
+++ b/runtime.js
@@ -1,35 +1,40 @@
-function program ({init, update, view, done}) {
-  let state
-  let isRunning = true
+module.exports = {
+  program: function (program) {
+    var update = program.update
+    var view = program.view
+    var done = program.done
+    var state
+    var isRunning = true
+    var timeout = setTimeout
 
-  function dispatch (message) {
-    if (isRunning) {
-      change(update(message, state))
+    function dispatch (message) {
+      if (isRunning) {
+        change(update(message, state))
+      }
     }
-  }
 
-  function change ([newState, effect]) {
-    state = newState
-    if (effect) {
-      setTimeout(() => effect(dispatch), 0)
-    }
-    view(state, dispatch)
-  }
-
-  change(init)
-
-  return function kill () {
-    if (!isRunning) {
-      return
-    }
-    isRunning = false
-    if (done) {
-      const effect = done(state)
+    function change (change) {
+      state = change[0]
+      var effect = change[1]
       if (effect) {
-        setTimeout(() => effect(), 0)
+        timeout(function () { effect(dispatch) }, 0)
+      }
+      view(state, dispatch)
+    }
+
+    change(program.init)
+
+    return function kill () {
+      if (!isRunning) {
+        return
+      }
+      isRunning = false
+      if (done) {
+        var effect = done(state)
+        if (effect) {
+          timeout(function () { effect() }, 0)
+        }
       }
     }
   }
 }
-
-module.exports = {program}

--- a/runtime.js
+++ b/runtime.js
@@ -1,5 +1,12 @@
-function program ({init, update, view}) {
+function program ({init, update, view, done}) {
   let state
+  let isRunning = true
+
+  function dispatch (message) {
+    if (isRunning) {
+      change(update(message, state))
+    }
+  }
 
   function change ([newState, effect]) {
     state = newState
@@ -9,11 +16,20 @@ function program ({init, update, view}) {
     view(state, dispatch)
   }
 
-  function dispatch (message) {
-    change(update(message, state))
-  }
-
   change(init)
+
+  return function kill () {
+    if (!isRunning) {
+      return
+    }
+    isRunning = false
+    if (done) {
+      const effect = done(state)
+      if (effect) {
+        setTimeout(() => effect(), 0)
+      }
+    }
+  }
 }
 
 module.exports = {program}

--- a/test/runtime.js
+++ b/test/runtime.js
@@ -37,3 +37,79 @@ test('program() should call view() after dispatch', t => {
     })
   }).then(() => t.is(count, 3))
 })
+
+test('program() should call done() when killed', t => {
+  t.plan(2)
+  return new Promise(resolve => {
+    const initialState = 'state'
+    const kill = program({
+      init: [initialState],
+      update (msg, state) {
+        return state
+      },
+      view () {},
+      done (state) {
+        t.is(state, initialState, 'the state is passed')
+        return () => {
+          t.pass('the effect is run')
+          resolve()
+        }
+      }
+    })
+
+    kill()
+  })
+})
+
+test('program() should not call update/view if killed', t => {
+  t.plan(2)
+  let initialRender = true
+  const initialState = 'state'
+  return new Promise(resolve => {
+    const afterKillEffect = dispatch => {
+      t.is(typeof dispatch, 'function', 'dispatch is passed')
+      setTimeout(() => {
+        dispatch()
+        resolve()
+      }, 10)
+    }
+    const kill = program({
+      init: [initialState, afterKillEffect],
+      update () {
+        t.fail('update() should not be called')
+      },
+      view () {
+        if (initialRender) {
+          initialRender = false
+          t.pass('view() is called once')
+          return
+        }
+
+        t.fail('view() should not be called more than once')
+      }
+    })
+
+    kill()
+  })
+})
+
+test('program() should only call done() once', t => {
+  let initialCall = true
+  const kill = program({
+    init: [],
+    update () {},
+    view () {},
+    done () {
+      if (initialCall) {
+        initialCall = false
+        t.pass('done() was called once')
+        return
+      }
+
+      t.fail('done() should not be called more than once')
+    }
+  })
+
+  kill()
+  kill()
+})


### PR DESCRIPTION
This is the last thing that Raj needed to solve: how to kill it. Until now we could start runtimes, and they would run indefinitely. Now to end a Raj program, you do:

```js
const kill = program(myProgram)
kill() // runtime stops updating and all incoming messages are dropped
```

This is important, especially for our view library integrations. Now view libraries that deal in components can clean up the runtime when the root component is removed or replaced.

This also solves problems for subscription effects. When the runtime is destroyed it will call the program's `done` function if it exists. The `done` will receive the state, similar to `view` without the `dispatch` function, and may return an optional effect to be run (which cannot dispatch messages). For example, [`raj-spa`](https://github.com/andrejewski/raj-spa) subscribes to a router and when it is removed it needs to unsubscribe, otherwise route changes would be flowing in forever (and other memory problems). Now we can do:

```js
const myProgram = {
  init, update, view,
  done (model) {
    return model.routerCancel // effect to unsubscribe from the router
  }
}
```

It is important to note that `done` is optional so programs do not need to add a `done`. However if a subprogram does have a subscription you should lift up their `done` effects. The [`raj-compose`](https://github.com/andrejewski/raj-compose) package will help with this, as all utilities can work with `done`. 

It is important to note that this is the best we can do (I think) without making effects more complex. In Elm you don't have `done`, instead there is a `subscription` member to each program. In Elm, every new kind of effect needs an effect manager to deal with subscriptions, which are huge pains to write and get working correctly. Given how infrequently subscriptions are used in practice, splitting effects into one time commands and any time subscriptions does not seem necessary or as intuitive as this `done` approach.

---

Other changes:
- README updates, the example should be more prominent.
- The `runtime` module has been rewritten ES3 JavaScript. It is a bit longer because we cannot use destructuring or arrow functions. For those interested, the runtime is 262 byes minified.