### PR TITLE
Remove setTimeout wrapper

### DIFF
--- a/runtime.js
+++ b/runtime.js
@@ -15,7 +15,7 @@ exports.program = function (program) {
     state = change[0]
     var effect = change[1]
     if (effect) {
-      setTimeout(function () { effect(dispatch) }, 0)
+      effect(dispatch)
     }
     view(state, dispatch)
   }


### PR DESCRIPTION
This `setTimeout` wrapper was originally added as a safety rail/simple queuing system. I intended to make synchronous mutation buggy and present those bugs faster. However, this is JavaScript; there are correct ways to write code and we can only help people along so much. It's better not to do anything special in the main runtime. It's easy to make alternate runtimes. Testing without the setTimeout shows no change in behavior in unit tests or in real world applications.

As we more towards v1.0, I'm looking to remove this cruft because it's just one more thing to conceptualize and relying on a global `setTimeout` in the core of the framework never really appealed to me.

This will require a change to `raj-react` which expects the first state transition to be async. Luckily, having looked at the updated React docs the rewrite of that will actually make the React bindings smaller than the framework by line count. So this is a win-win change for code size.